### PR TITLE
Add .gitignore to exclude build and report files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Maven ve Java derleme dosyaları
+/target/
+*.class
+*.log
+
+# IDE ve editor dosyaları
+.idea/
+.vscode/
+.DS_Store
+
+# Allure raporları ve geçici test sonuçları
+allure-results/
+allure-report/
+test-report/
+
+# Sistem dosyaları
+Thumbs.db


### PR DESCRIPTION
- Introduced a comprehensive .gitignore file to prevent build artifacts, IDE/editor files, and generated test reports from being committed to the repository.
- This ensures a clean codebase, facilitates collaboration, and keeps version control focused solely on source code and configuration.