### PR TITLE
Add .gitattributes to set Java as the main language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Exclude Allure report and HTML files from language statistics
+allure-report/* linguist-vendored
+docs/* linguist-vendored
+*.html linguist-vendored
+
+# Set Java files as the main language
+*.java linguist-language=Java


### PR DESCRIPTION
Adds .gitattributes to exclude HTML reports from language stats and make Java the main language shown on GitHub.