### PR TITLE
Add .gitattributes to set Java as the main language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 allure-report/* linguist-vendored
 docs/* linguist-vendored
 *.html linguist-vendored
+*.js linguist-vendored
 
 # Set Java files as the main language
 *.java linguist-language=Java


### PR DESCRIPTION
This pull request adds a .gitattributes file to the project root to ensure that Java is shown as the main language on GitHub.
	•	Excludes HTML, JavaScript, and report files (such as those in allure-report/ and docs/ folders) from language statistics
	•	Sets Java files as the primary language

This update provides a more accurate language breakdown for the repository.