### PR TITLE
Update .gitattributes to only show Java as the main language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,8 @@ allure-report/* linguist-vendored
 docs/* linguist-vendored
 *.html linguist-vendored
 *.js linguist-vendored
+*.css linguist-vendored
+Dockerfile linguist-vendored
 
 # Set Java files as the main language
 *.java linguist-language=Java


### PR DESCRIPTION
This pull request updates the .gitattributes file to exclude HTML, JavaScript, CSS, and Dockerfile from the language statistics (including files in the allure-report/ and docs/ folders).
This change ensures that GitHub displays Java as the main language for the repository.